### PR TITLE
Kustomize resource definitions (base + UAT overlay)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,10 @@
   - Docker supported.
   - Backend startup orchestration in `backend/entrypoint.sh` (collectstatic, migrate, gunicorn).
 
+## Kubernetes Kustomize Configuration
+- Kubernetes manifests for Authorisations are managed under `kustomize/` using a base + overlays structure.
+- Primary operator documentation is in `kustomize/README.md`.
+
 ## Business Logic Behind Technical Structure
 
 ### Why `AuthorisationProcess` Exists

--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,7 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
-# Environments
+# Environments/secrets
 .env
 .venv
 env/
@@ -135,6 +135,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.prince2-license
 
 # Spyder project settings
 .spyderproject

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -2,6 +2,14 @@
 
 Declarative management of Authorisations Kubernetes resources using Kustomize.
 
+## Important usage rule
+
+Do not apply `kustomize/base` directly.
+
+The base manifests are shared building blocks and are intentionally incomplete for standalone deployment (for example, environment-specific selectors, generated secret/config map names, ingress, and other wiring are provided by overlays).
+
+Always apply an overlay such as `kustomize/overlays/uat`.
+
 ## File structure
 
 ```
@@ -48,6 +56,9 @@ Review the built resource output using `kustomize`:
 ```bash
 # Review UAT configuration
 kustomize build kustomize/overlays/uat/ | less
+
+# Do not build/apply base directly
+# kustomize build kustomize/base/
 ```
 
 ### 3. Deploy to Kubernetes

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -56,7 +56,7 @@ Run `kubectl` with the `-k` flag to generate resources for a given overlay:
 
 ```bash
 # Dry run
-kubectl apply -k kustomize/overlays/uat/ --namespace authorisation --dry-run=server
+kubectl apply -k kustomize/overlays/uat/ --namespace authorisations --dry-run=server
 
 # Apply
 kubectl apply -k kustomize/overlays/uat/ --namespace authorisations

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,0 +1,69 @@
+# Authorisations Kustomize configuration
+
+Declarative management of Authorisations Kubernetes resources using Kustomize.
+
+## File structure
+
+```
+kustomize/
+├── base/                    # Base configuration (shared)
+│   ├── deployment.yaml
+│   ├── deployment_hpa.yaml
+│   ├── kustomization.yaml
+│   └── service.yaml
+└── overlays/
+    ├── prod/                # Production overlay
+    │   ├── deployment_patch.yaml
+    │   ├── ingress.yaml
+    │   ├── kustomization.yaml
+    │   └── ...
+    └── uat/                # UAT overlay
+        ├── deployment_patch.yaml
+        ├── ingress.yaml
+        ├── kustomization.yaml
+        └── ...
+```
+
+## How to use
+
+### 1. Create environment files
+
+Within an overlay directory, create a `.env` file to contain required secret values in the format `KEY=value` (e.g., `overlays/uat/.env`).
+
+**Required values:**
+
+```bash
+DATABASE_URL=postgresql://user:pass@host:5432/dbname
+SECRET_KEY=your-secret-key-here
+DEBUG=False
+# ... see backend/.env.template for full list
+```
+
+Also create a `.prince2-license` file containing XML license content. This will be mounted in running pods as a ConfigMap during deployment.
+
+### 2. Review configuration
+
+Review the built resource output using `kustomize`:
+
+```bash
+# Review UAT configuration
+kustomize build kustomize/overlays/uat/ | less
+```
+
+### 3. Deploy to Kubernetes
+
+Run `kubectl` with the `-k` flag to generate resources for a given overlay:
+
+```bash
+# Dry run
+kubectl apply -k kustomize/overlays/uat/ --namespace authorisation --dry-run=server
+
+# Apply
+kubectl apply -k kustomize/overlays/uat/ --namespace authorisations
+```
+
+## References
+
+- [Kubernetes Kustomize Documentation](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/)
+- [Kustomize GitHub Repository](https://github.com/kubernetes-sigs/kustomize)
+- [Kustomize Examples](https://github.com/kubernetes-sigs/kustomize/tree/master/examples)

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -61,7 +61,22 @@ kustomize build kustomize/overlays/uat/ | less
 # kustomize build kustomize/base/
 ```
 
-### 3. Deploy to Kubernetes
+### 3. Preflight validation
+
+Validate generated manifests before deployment:
+
+```bash
+# 1) Ensure overlay builds successfully
+kustomize build kustomize/overlays/uat/ > /tmp/authorisations-uat.yaml
+
+# 2) Client-side validation (syntax and basic schema checks)
+kubectl apply --dry-run=client --validate=true -f /tmp/authorisations-uat.yaml
+
+# 3) Server-side validation against the target cluster API
+kubectl apply --dry-run=server -f /tmp/authorisations-uat.yaml --namespace authorisations
+```
+
+### 4. Deploy to Kubernetes
 
 Run `kubectl` with the `-k` flag to generate resources for a given overlay:
 

--- a/kustomize/base/deployment.yaml
+++ b/kustomize/base/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authorisations
+spec:
+  strategy:
+    type: RollingUpdate
+  template:
+    spec:
+      containers:
+        - name: authorisations
+          image: ghcr.io/dbca-wa/authorisations
+          resources:
+            requests:
+              memory: '200Mi'
+              cpu: '10m'
+            limits:
+              memory: '2Gi'
+              cpu: '1000m'
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 5000
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmpfs-ram
+      volumes:
+        - name: tmpfs-ram
+          emptyDir:
+            medium: 'Memory'
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 180
+      automountServiceAccountToken: false
+      affinity:
+        # Set a pod anti-affinity to spread pods between nodes (preference only).
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: prs-deployment
+                topologyKey: kubernetes.io/hostname

--- a/kustomize/base/deployment_hpa.yaml
+++ b/kustomize/base/deployment_hpa.yaml
@@ -1,0 +1,17 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: authorisations-hpa
+spec:
+  minReplicas: 2
+  maxReplicas: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 500
+      type: Resource

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - deployment_hpa.yaml
+  - service.yaml

--- a/kustomize/base/service.yaml
+++ b/kustomize/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: authorisations-clusterip
+spec:
+  type: ClusterIP
+  ports:
+    - name: wsgi
+      port: 8080
+      protocol: TCP
+      targetPort: 8080

--- a/kustomize/overlays/uat/deployment_hpa_patch.yaml
+++ b/kustomize/overlays/uat/deployment_hpa_patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: authorisations-hpa
+spec:
+  scaleTargetRef:
+    name: authorisations-uat

--- a/kustomize/overlays/uat/deployment_patch.yaml
+++ b/kustomize/overlays/uat/deployment_patch.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authorisations
+  labels:
+    app: authorisations-uat
+spec:
+  selector:
+    matchLabels:
+      app: authorisations-uat
+  template:
+    metadata:
+      labels:
+        app: authorisations-uat
+    spec:
+      containers:
+        - name: authorisations
+          envFrom:
+            - secretRef:
+                name: authorisations-env-uat
+          volumeMounts:
+            - name: prince2-license-uat
+              mountPath: /usr/lib/prince/license
+              readOnly: true
+      volumes:
+        - name: prince2-license-uat
+          configMap:
+            defaultMode: 420
+            name: prince2-license-uat

--- a/kustomize/overlays/uat/ingress.yaml
+++ b/kustomize/overlays/uat/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: authorisations-uat-internal-oim03.dbca.wa.gov.au
+    - host: authorisations-uat.dbca.wa.gov.au
       http:
         paths:
           - path: /

--- a/kustomize/overlays/uat/ingress.yaml
+++ b/kustomize/overlays/uat/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: authorisations-uat.dbca.wa.gov.au
+    - host: authorisations-uat-internal-oim03.dbca.wa.gov.au
       http:
         paths:
           - path: /

--- a/kustomize/overlays/uat/ingress.yaml
+++ b/kustomize/overlays/uat/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: authorisations-ingress
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: authorisations-uat.dbca.wa.gov.au
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: authorisations-clusterip-uat
+                port:
+                  number: 8080

--- a/kustomize/overlays/uat/kustomization.yaml
+++ b/kustomize/overlays/uat/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -uat
+secretGenerator:
+  - name: authorisations-env
+    type: Opaque
+    envs:
+      - .env
+configMapGenerator:
+  - name: prince2-license
+    files:
+      - .prince2-license
+generatorOptions:
+  disableNameSuffixHash: true
+resources:
+  - ../../base
+  - ingress.yaml
+  - pdb.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      variant: uat
+patches:
+  - path: deployment_patch.yaml
+  - path: deployment_hpa_patch.yaml
+  - path: service_patch.yaml
+images:
+  - name: ghcr.io/dbca-wa/authorisations
+    newTag: uat

--- a/kustomize/overlays/uat/pdb.yaml
+++ b/kustomize/overlays/uat/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: authorisations-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: authorisations-uat
+      variant: uat

--- a/kustomize/overlays/uat/service_patch.yaml
+++ b/kustomize/overlays/uat/service_patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: authorisations-clusterip
+spec:
+  type: ClusterIP
+  selector:
+    app: authorisations-uat
+    variant: uat


### PR DESCRIPTION
Declarative Kubernetes resource definitions in name with DBCA operational patterns. UAT overlay only (should be generally compatible with existing manually-deployed resources, with some naming differences).